### PR TITLE
chore(release): v1.3.0 운영 반영

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,8 @@ logs
 .eslintcache
 .node_repl_history
 .yarn-integrity
+.env
 .env.local
 .env.development.local
 .env.test.local
-.env.production.local 
+.env.production.local

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,4 +1,4 @@
-name: Docker Build and Push
+name: Docker Build and Deploy
 
 on:
   push:
@@ -16,6 +16,8 @@ env:
   AWS_REGION: ap-northeast-2
   ECS_CLUSTER: default
   ECS_SERVICE: kiki-file-server-task-service
+  ECS_TASK_FAMILY: kiki-file-server-task
+  CONTAINER_NAME: kiki-file-server-task
 
 jobs:
   # PR: 빌드 테스트만
@@ -59,18 +61,17 @@ jobs:
           username: ${{ secrets.DOCKER_USER_NAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_IMAGE }}
-          tags: |
-            # 태그 push 시: v1.2.0 -> 1.2.0
-            type=semver,pattern={{version}}
-            # main 브랜치 push 시: latest
-            type=raw,value=latest,enable={{is_default_branch}}
-            # 커밋 SHA (항상)
-            type=sha,prefix=
+      - name: Determine image tag
+        id: image-tag
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            TAG="${{ github.ref_name }}"
+            TAG="${TAG#v}"
+          else
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Image tag: $TAG"
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
@@ -78,15 +79,16 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:${{ steps.image-tag.outputs.tag }}
+            ${{ env.DOCKER_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Print image tags
         run: |
           echo "Pushed tags:"
-          echo "${{ steps.meta.outputs.tags }}"
+          echo "${{ env.DOCKER_IMAGE }}:${{ steps.image-tag.outputs.tag }}"
 
       # ECS 배포
       - name: Configure AWS credentials
@@ -99,60 +101,76 @@ jobs:
       - name: Get current task definition
         id: task-def
         run: |
-          TASK_DEF_ARN=$(aws ecs describe-services \
-            --cluster ${{ env.ECS_CLUSTER }} \
-            --services ${{ env.ECS_SERVICE }} \
-            --query 'services[0].taskDefinition' \
-            --output text)
-          echo "task_def_arn=$TASK_DEF_ARN" >> $GITHUB_OUTPUT
-
-          TASK_DEF_NAME=$(echo $TASK_DEF_ARN | cut -d'/' -f2 | cut -d':' -f1)
-          echo "task_def_name=$TASK_DEF_NAME" >> $GITHUB_OUTPUT
-
-      - name: Download task definition
-        run: |
           aws ecs describe-task-definition \
-            --task-definition ${{ steps.task-def.outputs.task_def_name }} \
+            --task-definition ${{ env.ECS_TASK_FAMILY }} \
             --query 'taskDefinition' \
             > task-definition.json
 
           # 불필요한 필드 제거
-          cat task-definition.json | jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' > clean-task-definition.json
+          jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' \
+            task-definition.json > clean-task-definition.json
           mv clean-task-definition.json task-definition.json
 
-      - name: Determine image tag
-        id: image-tag
+      - name: Update task definition with new image and environment variables
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            # 태그인 경우: v1.2.0 -> 1.2.0
-            TAG="${{ github.ref_name }}"
-            TAG="${TAG#v}"
-          else
-            # main 브랜치인 경우
-            TAG="latest"
-          fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Image tag: $TAG"
+          # 환경변수 배열 생성
+          ENV_VARS='[
+            {"name": "NODE_ENV", "value": "production"},
+            {"name": "PORT", "value": "80"},
+            {"name": "WEBDAV_URL", "value": "${{ secrets.WEBDAV_URL }}"},
+            {"name": "WEBDAV_USER", "value": "${{ secrets.WEBDAV_USER }}"},
+            {"name": "WEBDAV_PASSWORD", "value": "${{ secrets.WEBDAV_PASSWORD }}"},
+            {"name": "DB_HOST", "value": "${{ secrets.DB_HOST }}"},
+            {"name": "DB_PORT", "value": "${{ secrets.DB_PORT }}"},
+            {"name": "DB_USER", "value": "${{ secrets.DB_USER }}"},
+            {"name": "DB_PASSWORD", "value": "${{ secrets.DB_PASSWORD }}"},
+            {"name": "DB_NAME", "value": "${{ secrets.DB_NAME }}"}
+          ]'
 
-      - name: Update task definition with new image
-        id: render-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: task-definition.json
-          container-name: ${{ env.ECS_SERVICE }}
-          image: ${{ env.DOCKER_IMAGE }}:${{ steps.image-tag.outputs.tag }}
+          # Task Definition 업데이트 (이미지 + 환경변수)
+          jq --arg IMAGE "${{ env.DOCKER_IMAGE }}:${{ steps.image-tag.outputs.tag }}" \
+             --argjson ENV_VARS "$ENV_VARS" \
+             '.containerDefinitions[0].image = $IMAGE | .containerDefinitions[0].environment = $ENV_VARS' \
+             task-definition.json > updated-task-definition.json
 
-      - name: Deploy to ECS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE }}
-          cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability: true
+          mv updated-task-definition.json task-definition.json
+
+          echo "Updated task definition:"
+          cat task-definition.json | jq '.containerDefinitions[0] | {image, environment: [.environment[].name]}'
+
+      - name: Register new task definition
+        id: register-task-def
+        run: |
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file://task-definition.json \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          echo "task_def_arn=$TASK_DEF_ARN" >> $GITHUB_OUTPUT
+          echo "Registered task definition: $TASK_DEF_ARN"
+
+      - name: Update ECS service
+        run: |
+          aws ecs update-service \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ env.ECS_SERVICE }} \
+            --task-definition ${{ steps.register-task-def.outputs.task_def_arn }} \
+            --force-new-deployment
+
+          echo "Service update initiated"
+
+      - name: Wait for service stability
+        run: |
+          echo "Waiting for service to stabilize..."
+          aws ecs wait services-stable \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_SERVICE }}
+          echo "Service is stable"
 
       - name: Deployment complete
         run: |
+          echo "======================================"
           echo "Deployment complete!"
           echo "Image: ${{ env.DOCKER_IMAGE }}:${{ steps.image-tag.outputs.tag }}"
           echo "Cluster: ${{ env.ECS_CLUSTER }}"
           echo "Service: ${{ env.ECS_SERVICE }}"
+          echo "======================================"


### PR DESCRIPTION
## 운영 배포 개요
  - 버전: v1.3.0
  - 배포 대상: production (main)
  - 배포 트리거:
    - main merge → latest 배포
    - tag push → v1.3.0 배포

  ---

  ## 주요 변경 사항

  ### 1. CI/CD 파이프라인 구축
  - GitHub Actions 워크플로우 추가
  - Docker Hub 이미지 빌드/푸시 자동화
  - ECS 자동 배포 설정
  - GitHub Secrets 기반 환경변수 주입 방식 적용

  ### 2. Git Flow 브랜치 전략 도입
  - main / develop / feature / release / hotfix 브랜치 구조
  - BRANCH_STRATEGY.md 문서 추가

  ### 3. WebDAV 업로드 안정성 개선
  - 중복 파일명 자동 처리 (`파일명(1).확장자`)
  - 업로드 진행 상태 로깅
  - 경로 처리 버그 수정

  ### 4. ETag 기반 파일 버전 관리 (기반 구축)
  - 파일 메타데이터 DB 저장 구조
  - (버전 체크 로직은 추후 완성 예정)

  ---

  ## 배포 전 체크리스트
  - [x] develop 변경사항 검증 완료
  - [x] CI/CD 워크플로우 설정 완료
  - [x] GitHub Secrets 환경변수 설정 필요
  - [ ] 프로덕션 DB 테이블 생성 필요
  - [x] 태그 생성 예정 (머지 후)

  ---

  ## 태그 생성 (머지 후)
  ```bash
  git checkout main && git pull origin main
  git tag v1.3.0 && git push origin v1.3.0